### PR TITLE
[Hotfix] fix request entity too large-errors

### DIFF
--- a/file-service.js
+++ b/file-service.js
@@ -9,7 +9,6 @@ const conf = require('./conf');
 const upload = require('./upload-config');
 const dateStarted = new Date();
 
-app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
   extended: false
 }));


### PR DESCRIPTION
removes duplicate bodyParser
