### PR TITLE
[DEV] add endpoint for get file by key

### DIFF
--- a/file-service.ts
+++ b/file-service.ts
@@ -15,6 +15,7 @@ import errors from "./lib/errors";
 import DeleteFilesHandler from "./lib/handlers/DeleteFilesHandler";
 import GetFilesHandler from "./lib/handlers/GetFilesHandler";
 import GetImageHandler from "./lib/handlers/GetImageHandler";
+import GetFileByKeyHandler from "./lib/handlers/GetFileByKeyHandler";
 import GetSignedUrlHandler from "./lib/handlers/GetSignedUrlHandler";
 import UpdateImageHandler from "./lib/handlers/UpdateImageHandler";
 import UploadFileHandler from "./lib/handlers/UploadFileHandler";
@@ -112,10 +113,7 @@ export async function start(busAddress: string, httpServerPort: number) {
 		const fileManager = new FileManager();
 
 		const deleteFilesHandler = new DeleteFilesHandler();
-		const updateImageHandler = new UpdateImageHandler(
-			inMemoryImageCacheRepo,
-			fileManager
-		);
+		const updateImageHandler = new UpdateImageHandler(inMemoryImageCacheRepo, fileManager);
 
 		bus.subscribe({
 			subject: constants.endpoints.http.bus.HEALTH,
@@ -157,6 +155,7 @@ export async function start(busAddress: string, httpServerPort: number) {
 
 		const uploadFileHandler = new UploadFileHandler();
 		const getImageHandler = new GetImageHandler(inMemoryImageCacheRepo, fileManager);
+		const getFileByKeyHandler = new GetFileByKeyHandler();
 
 		if (busAddress.includes("mock")) {
 			/*
@@ -184,6 +183,15 @@ export async function start(busAddress: string, httpServerPort: number) {
 			try {
 				// @ts-ignore
 				await getImageHandler.handle(req, res);
+			} catch (err) {
+				res.set("Cache-Control", "max-age=0");
+				res.end(JSON.stringify(err));
+			}
+		});
+
+		app.get(constants.endpoints.http.GET_FILE, async (req, res) => {
+			try {
+				await getFileByKeyHandler.handleHttp(req, res);
 			} catch (err) {
 				res.set("Cache-Control", "max-age=0");
 				res.end(JSON.stringify(err));

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -16,11 +16,11 @@ export default {
 
 			GET_IMAGE: "/image/:imageName",
 
+			GET_FILE: "/file/:fileKey",
+
 			bus: {
 
 				UPLOAD_FILE: `http.post.${conf.serviceName}.upload`,
-
-				GET_IMAGE: `http.get.${conf.serviceName}.image.:imageName.:type`,
 
 				UPDATE_IMAGE: `http.put.${conf.serviceName}.image.:imageName`,
 

--- a/lib/handlers/GetFileByKeyHandler.ts
+++ b/lib/handlers/GetFileByKeyHandler.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from "express";
+
+import S3Client from "../clients/S3Client";
+import { S3 } from "aws-sdk";
+
+class GetFileByKeyHandler {
+
+	s3 = new S3Client();
+
+	/**
+	 * Handle http request.
+	 */
+	async handleHttp({ params: { fileKey } }: Request, res: Response) {
+		const { data, mimetype } = await this.s3.getObject(fileKey);
+		return this.sendResponse(res, data, mimetype);
+	}
+
+	private sendResponse(res: Response, data: S3.Body, mimetype?: string) {
+		res.type(mimetype || "application/octet-stream");
+		return res.send(data);
+	}
+}
+
+export default GetFileByKeyHandler;

--- a/spec/GetFileByKeyHandler.spec.ts
+++ b/spec/GetFileByKeyHandler.spec.ts
@@ -1,0 +1,49 @@
+import bus from "fruster-bus";
+import testUtils from "fruster-test-utils";
+
+import { start } from "../file-service";
+import constants from "../lib/constants";
+
+import specUtils from "./support/spec-utils";
+
+describe("GetFileKeyHandler", () => {
+	let httpPort = 0;
+	let baseUri = "";
+
+	afterEach(() => {
+		specUtils.removeFilesInDirectory(constants.temporaryImageLocation);
+	});
+
+	testUtils.startBeforeEach(/**
+		 * @param {{ natsUrl: string; }} connection
+		 */
+		{
+			mockNats: true,
+			// @ts-ignore
+			service: async (connection) => {
+				do {
+					httpPort = Math.floor(Math.random() * 6000 + 3000);
+				} while (httpPort === 3410);
+
+				baseUri = `http://127.0.0.1:${httpPort}`;
+
+				return await start(connection.natsUrl!, httpPort);
+			},
+			bus
+		});
+
+	async function uploadFile(file: string) {
+		const { body: { data: { key } } } = await specUtils.post(baseUri, constants.endpoints.http.UPLOAD_FILE, file);
+
+		return key;
+	}
+
+	it("should be possible to get file by key", async () => {
+		const fileKey = await uploadFile("data/tiny.jpg");
+
+		const { body } = await specUtils.get(baseUri, `/file/${fileKey}`);
+
+		expect(body).toBeDefined();
+		expect(body.length > 7000 && body.length < 8000).toBeTruthy();
+	});
+});


### PR DESCRIPTION
This endpoint because if s3 bucket has not public-read permission. 
Also this will allow to keep only file key in the related db, without saving whole URL. 