### PR TITLE
Exposes MOCK_S3 config

### DIFF
--- a/conf.ts
+++ b/conf.ts
@@ -59,7 +59,10 @@ export default {
 	// Image proxy uri to be returned for proxied images
 	proxyImageUrl: process.env.PROXY_IMAGE_URL || "http://localhost:" + port,
 
-	serviceHttpUrl: process.env.DEIS_APP ? "http://" + process.env.DEIS_APP + "." + process.env.DEIS_APP : "http://localhost:" + port
+	serviceHttpUrl: process.env.DEIS_APP ? "http://" + process.env.DEIS_APP + "." + process.env.DEIS_APP : "http://localhost:" + port,
+
+	// If to mock S3 and instead serve files locally, should only be used in test scenarios
+	mockS3: process.env.MOCK_S3 === "true"
 }
 
 

--- a/lib/clients/S3Client.ts
+++ b/lib/clients/S3Client.ts
@@ -10,7 +10,7 @@ import { ListObjectResponse } from "../models/ListObjectsResponse";
 const { s3Bucket, awsAccessKeyId, awsSecretAccessKey } = conf;
 
 // Mock S3 if tests
-const TheS3Client = process.env.CI ? mockAwsS3.S3 : AWS.S3;
+const TheS3Client = process.env.CI || conf.mockS3 ? mockAwsS3.S3 : AWS.S3;
 class S3Client {
 
 	s3 = new TheS3Client({


### PR DESCRIPTION
Exposes config `MOCK_S3` that if set, will use mocked S3. 

This can be useful i.e. when running service locally but you don't want full S3 integration. 

This was previously only used in tests.