### PR TITLE
Fix/vipsjpeg premature end of input file error

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -19,6 +19,7 @@ health.start();
 
 process.on("uncaughtException", (err) => {
 	log.error(err);
+	console.error(err?.stack);
 	if (err.message && err.message.includes("ECONNRESET")) {
 		health.fail("Service failure due to ECONNRESET");
 	}

--- a/lib/managers/FileManager.ts
+++ b/lib/managers/FileManager.ts
@@ -64,7 +64,7 @@ class FileManager {
 		//write stream for new file
 		const file = await fs.createWriteStream(newFileLocation);
 
-		let updatedFile = sharp(tmpImage);
+		let updatedFile = sharp(tmpImage, {failOnError: false});
 
 		// resize
 		if (query.height || query.width)


### PR DESCRIPTION
Fixes, or at least avoid similar issue to this https://github.com/lovell/sharp/issues/1859

Also improves logging on uncaught exceptions.