### PR TITLE
[ FIX ] Enable role-based auth

### DIFF
--- a/conf.ts
+++ b/conf.ts
@@ -25,10 +25,10 @@ export default {
 	allowOrigin: parseArray(process.env.ALLOW_ORIGIN) || "*",
 
 	// AWS Access key id
-	awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID,
+	awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID || process.env.S3_ACCESS_KEY,
 
 	// AWS Secret access key
-	awsSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+	awsSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || process.env.S3_SECRET,
 
 	// ACL for uploaded files, defaults to public-read which will make
 	// uploaded files public

--- a/conf.ts
+++ b/conf.ts
@@ -25,10 +25,10 @@ export default {
 	allowOrigin: parseArray(process.env.ALLOW_ORIGIN) || "*",
 
 	// AWS Access key id
-	awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID || process.env.S3_ACCESS_KEY || "AKIAJPEXVPNKCC2H35AQ",
+	awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID,
 
 	// AWS Secret access key
-	awsSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || process.env.S3_SECRET || "0KK41oXRPZItRrhuwh+Sd+cfq2EntJXN4UHZpNrq",
+	awsSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
 
 	// ACL for uploaded files, defaults to public-read which will make
 	// uploaded files public

--- a/spec/IsProcessingCompletedHandler.spec.ts
+++ b/spec/IsProcessingCompletedHandler.spec.ts
@@ -54,7 +54,7 @@ describe("IsProcessingCompleted", () => {
 			body: { data: { url } }
 		} = await specUtils.post(baseUri, constants.endpoints.http.UPLOAD_FILE, "data/small.mp4");
 
-		await sleep(5000);
+		await sleep(8000);
 
 		const { status, data } = await bus.request<any, any>({
 			subject: SUBJECT,


### PR DESCRIPTION
As i understand, built-in role based auth in EKS pod should _just work_ if no access keys are set.